### PR TITLE
added calibration file to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.md
 include LICENSE
 include *.txt
-include ooipy/hydrophone/calibration_by_assetID.pkl
+include ooipy/hydrophone/calibration_by_assetID.csv

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
 include *.txt
+include ooipy/hydrophone/calibration_by_assetID.pkl


### PR DESCRIPTION
We have a file "calibration_by_assetID.pkl" in the hydrophone directory that contains calibration data for the hydrophones. I've added the file to the manifest so that if will be installed when installing the package. It seems to work when I tested it on my local machine, @lsetiawan do you see any issues or should this also work after we make a new release?