### PR TITLE
Os import error

### DIFF
--- a/ooipy/hydrophone/basic.py
+++ b/ooipy/hydrophone/basic.py
@@ -21,8 +21,9 @@ import pickle
 from scipy.io import wavfile
 import warnings
 import ooipy
-import pandas as pd
 import os
+import pandas as pd
+
 
 
 class HydrophoneData(Trace):

--- a/ooipy/hydrophone/basic.py
+++ b/ooipy/hydrophone/basic.py
@@ -25,7 +25,6 @@ import os
 import pandas as pd
 
 
-
 class HydrophoneData(Trace):
     """
     Object that stores hydrophone data


### PR DESCRIPTION
error where os is not imported on ooipy/hydrophone/basic.py

Not completely sure how good Github practice works for finding small bugs like this. @lsetiawan Do we need to create a new release tag for something this small?