### PR TITLE
Include csv in hydrophone module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ooipy/ooipy",
     packages=setuptools.find_packages(exclude=("tests")),
+    include_package_data=True,
+    package_data={"": ["hydrophone/*.csv"]},
     license="MIT",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR includes the csv file in hydrophone module as a package data. https://setuptools.readthedocs.io/en/latest/userguide/datafiles.html

Closes #63 

## Testing

You can try this out by:

1. Installing with pip from repo root directory in a conda environment.
     ``` bash
     pip install .
     ```

2. Then going to an outside folder and find where the package lives.
     ``` bash
     cd .. && python -c "import ooipy; print(ooipy.__path__)"
     ```
3. Go to that path and check for the csv. ![Screenshot from 2021-05-07 08-49-24](https://user-images.githubusercontent.com/17802172/117475659-2bdada80-af11-11eb-9de1-754d28d26374.png)


