### PR TITLE
ci: fix cache action

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -26,7 +26,7 @@ jobs:
         CACHE_NUMBER: 0
       with:
         path: ~/conda_pkgs_dir
-        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('conda_envs/py${{ matrix.python-version }}.yml') }}
+        key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(format('conda_envs/py{0}.yml', matrix.python-version)) }}
     - name: Install conda
       uses: conda-incubator/setup-miniconda@v2
       with:


### PR DESCRIPTION
Nested expressions are not allowed in GitHub Actions that's why this won't work `${{ hashFiles('conda_envs/py${{ matrix.python-version }}.yml') }}`, it resolves to empty string and resulting key becomes `Linux-conda-0-`.

This PR fixes hash creation with use of [format](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#format).

Before: `Linux-conda-0-`
After: `Linux-conda-0-eaaf5a7d99593b0d87a5a98773023ebb63066e5026fc32eb095be0dc22bd7f6a` where hash is calculated for each conda env file.

This should help speed up conda builds a bit because different Python versions will have different base cache. If only it was updateable...