### PR TITLE
chore: add common Python env names to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ dist/
 ooipy.egg-info/
 *.wav
 ooi_auth.txt
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/


### PR DESCRIPTION
I know many scientific folks use conda but for those of us who use Python venvs this will be helpful, I hope you understand.