### PR TITLE
ci: use pre-commit directly

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,12 +1,18 @@
-
 name: Lint code
 
-on: [pull_request, push]
+on: [workflow_dispatch, push]
 
 jobs:
   lint-code:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.2
+    - name: Install pre-commit
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pre-commit
+        pre-commit install
+    - name: Run all pre-commit hooks
+      run: |
+        pre-commit run --all-files


### PR DESCRIPTION
I've kept it similar to what you had earlier: one single job running all checks but it's possible to have more granularity and have one check for each tool, see picture below:

![image](https://user-images.githubusercontent.com/12860284/128421220-755c0b3f-8d49-4991-9d42-9e3ba0cc008e.png)

[Example run](https://github.com/orcasound/orca-action-workflow/actions/runs/1094447897)

Let me know if you'd like it better.

Fixes #84